### PR TITLE
paginate when requesting all invoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 1. Install the required dependencies running:
 
 ```bash
-npm run install
+npm install
 ```
 
 2. Build the project with the following command:

--- a/src/domain/faturasService.ts
+++ b/src/domain/faturasService.ts
@@ -38,7 +38,7 @@ export const getHighestClassification = async (fatura: Fatura, order: FaturaClas
 
 
 export const optimizeFaturas = async (fromDate: Date, toDate: Date) => {
-  const faturas = await portalFinancasGateway.getFaturas(fromDate, toDate)
+  const faturas = await portalFinancasGateway.getAllFaturas(fromDate, toDate)
 
   for (const fatura of faturas) {
     console.debug(`Handling fatura ${fatura.idDocumento} - NIF: ${fatura.nifEmitente} - ${fatura.nomeEmitente}`)
@@ -86,7 +86,7 @@ const adjustFaturasWithZeroBenefit = async (fromDate: Date, toDate: Date) => {
 }
 
 export const backupState = async (fromDate: Date, toDate: Date): Promise<Fatura[]> => {
-  return portalFinancasGateway.getFaturas(fromDate, toDate)
+  return portalFinancasGateway.getAllFaturas(fromDate, toDate)
 }
 
 export const restoreState = async (faturas: Fatura[]) : Promise<void> => {

--- a/src/gateways/portalFinancas.ts
+++ b/src/gateways/portalFinancas.ts
@@ -97,21 +97,21 @@ export const getAllFaturas = async (fromDate: Date, toDate: Date): Promise<Fatur
     } while (shouldRequestNextPage)
   }
 
-    const uniqueFaturas = allFaturas.reduce((acc, it) => {
-        // Remove duplicates and map
-        acc.set(it.idDocumento, {
-            idDocumento: it.idDocumento,
-            nifEmitente: it.nifEmitente,
-            nomeEmitente: it.nomeEmitente,
-            actividadeEmitente: it.actividadeEmitente as FaturaClassification,
-            dataEmissaoDocumento: it.dataEmissaoDocumento,
-            hashDocumento: it.hashDocumento
-        })
+  const uniqueFaturas = allFaturas.reduce((acc, it) => {
+    // Remove duplicates and map
+    acc.set(it.idDocumento, {
+      idDocumento: it.idDocumento,
+      nifEmitente: it.nifEmitente,
+      nomeEmitente: it.nomeEmitente,
+      actividadeEmitente: it.actividadeEmitente as FaturaClassification,
+      dataEmissaoDocumento: it.dataEmissaoDocumento,
+      hashDocumento: it.hashDocumento
+    })
 
-        return acc
-    }, new Map<number, Fatura>())
+    return acc
+  }, new Map<number, Fatura>())
 
-    return [...uniqueFaturas.values()]
+  return [...uniqueFaturas.values()]
 }
 
 export const getFaturas = async (fromDate: Date, toDate: Date): Promise<FetchFaturasResponse> => {


### PR DESCRIPTION
The invoices API has a limit of 300 invoices per page, and blocks requests with dates across multiple years.

Solution:
- Check if we're hitting the pagination limit. Continue to next page if we did.
- Iterate the API using single year periods.